### PR TITLE
poem 新規作成の手続きをコントローラーの外へ出した

### DIFF
--- a/app/controllers/poems_controller.rb
+++ b/app/controllers/poems_controller.rb
@@ -16,9 +16,8 @@ class PoemsController < ApplicationController
   end
 
   def create
-    @poem = current_user.poems.build(poem_params)
-    if @poem.save
-      notify_to_slack
+    @poem = PoemCreationService.create(current_user, poem_params, view_context: view_context)
+    if @poem.valid?
       redirect_to @poem
     else
       render :new
@@ -44,24 +43,5 @@ class PoemsController < ApplicationController
 
   def poem_params
     params.require(:poem).permit(:title, :description)
-  end
-
-  def notify_to_slack
-    text = <<-EOC
-------------------------
-新しいポエムが投稿されました
-
-▼Title
-#{@poem.title}
-
-▼URL
-#{url_for @poem}
-▼Author
-#{current_user.name}
-    EOC
-
-    if ENV['SLACK_CHANNEL'].present?
-      Slack.chat_postMessage text: text, username: "PoemMaster", channel: ENV['SLACK_CHANNEL']
-    end
   end
 end

--- a/app/services/poem_creation_service.rb
+++ b/app/services/poem_creation_service.rb
@@ -1,0 +1,39 @@
+class PoemCreationService
+  class << self
+    def create(user, parameters, view_context: nil)
+      new.create(user, parameters, view_context: view_context)
+    end
+  end
+
+  def create(user, parameters, view_context: nil)
+    poem = user.poems.build(parameters)
+    if poem.save
+      post_notification(poem, view_context)
+    end
+    poem
+  end
+
+  private
+
+  def post_notification(poem, view_context)
+    return unless view_context
+
+    message = notification_message_for(poem, view_context)
+    SlackNotificationService.post(message)
+  end
+
+  def notification_message_for(poem, view_context)
+    (<<-END).strip_heredoc
+      ------------------------
+      新しいポエムが投稿されました
+
+      ▼Title
+      #{poem.title}
+
+      ▼URL
+      #{view_context.poem_url(poem)}
+      ▼Author
+      #{poem.user.name}
+    END
+  end
+end

--- a/app/services/slack_notification_service.rb
+++ b/app/services/slack_notification_service.rb
@@ -1,0 +1,27 @@
+class SlackNotificationService
+  class << self
+    def post(message)
+      new.post(message)
+    end
+  end
+
+  def post(message)
+    return unless slack_configured?
+
+    Slack.chat_postMessage text: message, username: "PoemMaster", channel: slack_channel
+  end
+
+  private
+
+  def slack_configured?
+    slack_token && slack_channel
+  end
+
+  def slack_token
+    ENV['SLACK_TOKEN']
+  end
+
+  def slack_channel
+    ENV['SLACK_CHANNEL']
+  end
+end


### PR DESCRIPTION
## 概要

元々は Slack の設定がない場合にエラーにならないようにする修正をやろうとしていたのですが、先を越されてしまったのでｗ ついでに作ったリファクタリングを提案します。

poem 新規作成の際の Slack 通知がコントローラーにベタ書きになっていたので、外へ出してみました。コントローラーはシンプルになった代わりに、サービス側に `view_context` を渡す必要があるのがやや微妙な気もしますが :sweat_smile: その辺りが気にならないようでしたらマージしてもらえると嬉しいです。
