### PR TITLE
/read_poems で、jsonリクエスト時にはCSRF対策を外す

### DIFF
--- a/app/controllers/read_poems_controller.rb
+++ b/app/controllers/read_poems_controller.rb
@@ -5,7 +5,7 @@ class ReadPoemsController < ApplicationController
   def create
     current_user.read_poems.create(poem_id: params[:poem_id])
     if json_request?
-      render json: {status: :success}, status: :created
+      render json: { status: :success }, status: :created
     else
       redirect_to :back
     end
@@ -21,6 +21,7 @@ class ReadPoemsController < ApplicationController
   end
 
   private
+  
   def json_request?
     request.format.json?
   end

--- a/app/controllers/read_poems_controller.rb
+++ b/app/controllers/read_poems_controller.rb
@@ -1,13 +1,27 @@
 class ReadPoemsController < ApplicationController
   before_filter :login_required
+  skip_before_action :verify_authenticity_token, if: :json_request?
 
   def create
     current_user.read_poems.create(poem_id: params[:poem_id])
-    redirect_to :back
+    if json_request?
+      render json: {status: :success}, status: :created
+    else
+      redirect_to :back
+    end
   end
 
   def destroy
     current_user.read_poems.destroy(params[:id])
-    redirect_to :back
+    if json_request?
+      render nothing: true, status: :no_content
+    else
+      redirect_to :back
+    end
+  end
+
+  private
+  def json_request?
+    request.format.json?
   end
 end


### PR DESCRIPTION
API経由で「呼んだよ」を付ける際に、CSRF対策が効いていると、付けられないので外す